### PR TITLE
add unreal to platform mapping

### DIFF
--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -97,6 +97,7 @@ export const PLATFORM_TO_ICON = {
   stride3d: "stride3d",
   swift: "swift",
   unity: "unity",
+  unreal: "unreal",
   // Don't add new platforms down here!
   // Please add them where they belong alphabetically
 } as const;


### PR DESCRIPTION
svg's are there:

https://github.com/getsentry/platformicons/blob/7a81291d4216172066c794beb8448a638658e577/svg_80x80/unreal.svg

But missing the mapping