### PR TITLE
add ue4 until we move to unrealengine

### DIFF
--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -97,9 +97,9 @@ export const PLATFORM_TO_ICON = {
   stride3d: "stride3d",
   swift: "swift",
   unity: "unity",
-  // This will be deprecated in favor of 'unreal-engine'
+  // This will be deprecated in favor of 'unrealengine'
   ue4: "ue4",
-  "unreal-engine": "unreal-engine",
+  "unrealengine": "unrealengine",
   // Don't add new platforms down here!
   // Please add them where they belong alphabetically
 } as const;

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -99,7 +99,7 @@ export const PLATFORM_TO_ICON = {
   unity: "unity",
   // This will be deprecated in favor of 'unrealengine'
   ue4: "ue4",
-  "unrealengine": "unrealengine",
+  unrealengine: "unrealengine",
   // Don't add new platforms down here!
   // Please add them where they belong alphabetically
 } as const;

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -97,7 +97,9 @@ export const PLATFORM_TO_ICON = {
   stride3d: "stride3d",
   swift: "swift",
   unity: "unity",
-  unreal: "unreal",
+  // This will be deprecated in favor of 'unreal-engine'
+  ue4: "ue4",
+  "unreal-engine": "unreal-engine",
   // Don't add new platforms down here!
   // Please add them where they belong alphabetically
 } as const;

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -98,8 +98,8 @@ export const PLATFORM_TO_ICON = {
   swift: "swift",
   unity: "unity",
   // This will be deprecated in favor of 'unrealengine'
-  ue4: "ue4",
-  unrealengine: "unrealengine",
+  ue4: "unreal",
+  unrealengine: "unreal",
   // Don't add new platforms down here!
   // Please add them where they belong alphabetically
 } as const;


### PR DESCRIPTION
Our current docs have it as `ue4` but Unreal Engine 5 was announced and we'll have a single top level doc for "Unreal Engine" where we can document both versions, mobile and desktop.

For that reason I suggest adding now ue4 so the logo shows up on the current doc, until we move to top level:

https://docs.sentry.io/platforms/native/guides/ue4/