### PR TITLE
key for unreal icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformicons",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Web platform and framework icon set.",
   "main": "build/index.js",
   "source": "src/index.tsx",

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -105,6 +105,7 @@ export const PLATFORM_TO_ICON = {
   unity: "unity",
   // This will be deprecated in favor of 'unrealengine'
   ue4: "unreal",
+  unreal: "unreal",
   unrealengine: "unreal",
   // Don't add new platforms down here!
   // Please add them where they belong alphabetically


### PR DESCRIPTION
We've moved on to call it `unreal`: https://github.com/getsentry/sentry-docs/issues/2981#issuecomment-1028202576

In later versions we can drop ue4 and unrealengine