### PR TITLE
fix: image load default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platformicons",
-  "version": "4.4.1",
+  "version": "5.0.0",
   "description": "Web platform and framework icon set.",
   "main": "build/index.js",
   "source": "src/index.tsx",

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -160,12 +160,14 @@ const PlatformIcon = ({
   ...otherProps
 }: Props) => {
   const icon = getIcon(platform);
-  const iconPath = require(`../${
-    format === "lg" ? "svg_80x80" : "svg"
-  }/${icon}.svg`);
+  const iconPathRaw = require(
+    `../${format === 'lg' ? 'svg_80x80' : 'svg'}/${icon}.svg`
+  );
+  const iconPath = iconPathRaw?.default ?? iconPathRaw;
 
   const languageIcon = getLanguageIcon(platform);
-  const languageIconPath = require(`../svg/${languageIcon}.svg`);
+  const languageIconPathRaw = require(`../svg/${languageIcon}.svg`);
+  const languageIconPath = languageIconPathRaw?.default ?? languageIconPathRaw;
 
   if (withLanguageIcon && languageIcon !== icon && languageIcon !== "default") {
     return (

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -163,10 +163,12 @@ const PlatformIcon = ({
   const iconPathRaw = require(
     `../${format === 'lg' ? 'svg_80x80' : 'svg'}/${icon}.svg`
   );
+  // It seems with webpack5 we need to access the default prop
   const iconPath = iconPathRaw?.default ?? iconPathRaw;
 
   const languageIcon = getLanguageIcon(platform);
   const languageIconPathRaw = require(`../svg/${languageIcon}.svg`);
+  // It seems with webpack5 we need to access the default prop
   const languageIconPath = languageIconPathRaw?.default ?? languageIconPathRaw;
 
   if (withLanguageIcon && languageIcon !== icon && languageIcon !== "default") {

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -163,12 +163,10 @@ const PlatformIcon = ({
   const iconPathRaw = require(
     `../${format === 'lg' ? 'svg_80x80' : 'svg'}/${icon}.svg`
   );
-  // It seems with webpack5 we need to access the default prop
   const iconPath = iconPathRaw?.default ?? iconPathRaw;
 
   const languageIcon = getLanguageIcon(platform);
   const languageIconPathRaw = require(`../svg/${languageIcon}.svg`);
-  // It seems with webpack5 we need to access the default prop
   const languageIconPath = languageIconPathRaw?.default ?? languageIconPathRaw;
 
   if (withLanguageIcon && languageIcon !== icon && languageIcon !== "default") {


### PR DESCRIPTION
It seems Webpack 5 changes how `require` works with images and we need to pull out the URL of the image from the `.default` parameter of the result of `require`. Bumping the package to 5.0.0 since it's intended to work for Webpack 5.