### PR TITLE
fix(build): Include type definitions in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Web Platform and Framework Logo Set",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "files": [
+    "build/",
+    "svg/",
+    "svg_80x80/"
+  ],
   "source": "src/index.tsx",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running `yarn pack`, only the `main` file was being included. This lists all the files needed to create the package include the type declarations for typescript.