### PR TITLE
Add entry for SvelteKit platform

### DIFF
--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -57,6 +57,7 @@ export const PLATFORM_TO_ICON = {
   "javascript-react": "react",
   "javascript-remix": "remix",
   "javascript-svelte": "svelte",
+  "javascript-sveltekit": "svelte",
   "javascript-vue": "vue",
   "javascript-wasm": "wasm",
   ionic: "ionic",


### PR DESCRIPTION
This PR adds an entry to the `PLATFORM_TO_ICON` mapping. [SvelteKit](https://kit.svelte.dev/) doesn't really have its own logo, so I think it's fine to just use the [Svelte](https://svelte.dev/) icon.