### PR TITLE
ref(icon-map): Add map for node-serverlesscloud

### DIFF
--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -148,7 +148,7 @@ function getLanguageIcon(platform: string): Platform {
   return getIcon(language);
 }
 
-type Platform = (typeof PLATFORM_TO_ICON)[keyof typeof PLATFORM_TO_ICON];
+type Platform = typeof PLATFORM_TO_ICON[keyof typeof PLATFORM_TO_ICON];
 
 type Props = React.HTMLAttributes<HTMLDivElement | HTMLImageElement> & {
   platform: string;

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -72,7 +72,7 @@ export const PLATFORM_TO_ICON = {
   "node-express": "express",
   "node-gcpfunctions": "gcp",
   "node-koa": "koa",
-  "node-serverlesscloud": "serveless",
+  "node-serverlesscloud": "serverless",
   perl: "perl",
   php: "php",
   "php-laravel": "laravel",

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -72,6 +72,7 @@ export const PLATFORM_TO_ICON = {
   "node-express": "express",
   "node-gcpfunctions": "gcp",
   "node-koa": "koa",
+  "node-serverlesscloud": "serveless",
   perl: "perl",
   php: "php",
   "php-laravel": "laravel",
@@ -147,7 +148,7 @@ function getLanguageIcon(platform: string): Platform {
   return getIcon(language);
 }
 
-type Platform = typeof PLATFORM_TO_ICON[keyof typeof PLATFORM_TO_ICON];
+type Platform = (typeof PLATFORM_TO_ICON)[keyof typeof PLATFORM_TO_ICON];
 
 type Props = React.HTMLAttributes<HTMLDivElement | HTMLImageElement> & {
   platform: string;


### PR DESCRIPTION
This PR adds a map for the platform id "node-serverlesscloud" fixing the issue described here https://github.com/getsentry/sentry-docs/pull/6913#issuecomment-1542314210