### PR TITLE
build: Add module export, put main back into commonjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 build
+esmbuild

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "7.0.0",
   "description": "Web Platform and Framework Logo Set",
   "main": "build/index.js",
+  "module": "esmbuild/index.js",
   "types": "build/index.d.ts",
   "sideEffects": false,
   "files": [
     "build/",
+    "esmbuild/",
     "svg/",
     "svg_80x80/"
   ],
@@ -27,8 +29,7 @@
   },
   "homepage": "https://github.com/getsentry/platformicons",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "prepare": "yarn build"
   },
   "peerDependencies": {

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from 'react';
 
 export const PLATFORM_TO_ICON = {
   amazon: "amazon",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "declaration": false,
+    "outDir": "esmbuild",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "build",
-    "module": "esnext",
+    "module": "CommonJS",
     "target": "ES2020",
     "lib": ["esnext", "dom"],
+    "esModuleInterop": true,
     "sourceMap": true,
     "allowJs": false,
     "jsx": "react",
@@ -15,8 +16,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "allowSyntheticDefaultImports": true
+    "noUnusedParameters": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "build"]


### PR DESCRIPTION
Forgot about jest requiring commonjs. Put the "main" back into commonjs and supplies a "module" build that is in esm that can be used by webpack or other bundlers.

I would've put this inside /build/esm directory but we use relative imports to import svg files so they need to both be at the top level