### PR TITLE
feat: Update normalize func to replace node- prefixes with javascript-

### DIFF
--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -232,23 +232,6 @@ export const PLATFORM_TO_ICON = {
 } as const;
 
 
-// DO NOT EXPORT THIS MAP. 
-// It's in place to ensure compatibility with existing code that uses the "node" prefix.
-const NODE_TO_JS_MAP = {
-  "node-awslambda": "javascript-awslambda",
-  "node-azurefunctions": "javascript-azurefunctions",
-  "node-cloudflare-pages": "javascript-cloudflare-pages",
-  "node-cloudflare-workers": "javascript-cloudflare-workers",
-  "node-connect": "javascript-connect",
-  "node-express": "javascript-express",
-  "node-fastify": "javascript-fastify",
-  "node-gcpfunctions": "javascript-gcpfunctions",
-  "node-hapi": "javascript-hapi",
-  "node-koa": "javascript-koa",
-  "node-nestjs": "javascript-nestjs",
-  "node-serverlesscloud": "javascript-serverlesscloud",
-}
-
 function normalizePlatform(platform: string): string {
   // sentry uses format python-django, but docs uses python.django
   // this function normalizes that

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -133,18 +133,6 @@ export const PLATFORM_TO_ICON = {
   nintendo: "nintendo",
   "nintendo-switch": "nintendo-switch",
   node: "nodejs",
-  "node-awslambda": "awslambda",
-  "node-azurefunctions": "azure-functions",
-  "node-cloudflare-pages": "cloudflare",
-  "node-cloudflare-workers": "cloudflare",
-  "node-connect": "connect",
-  "node-express": "express",
-  "node-fastify": "fastify",
-  "node-gcpfunctions": "gcp-functions",
-  "node-hapi": "hapi",
-  "node-koa": "koa",
-  "node-nestjs": "nestjs",
-  "node-serverlesscloud": "serverless",
   nvidia: "nvidia",
   openai: "openai",
   openfeature: "openfeature",
@@ -243,10 +231,30 @@ export const PLATFORM_TO_ICON = {
   // Please add them where they belong alphabetically
 } as const;
 
+
+// DO NOT EXPORT THIS MAP. 
+// It's in place to ensure compatibility with existing code that uses the "node" prefix.
+const NODE_TO_JS_MAP = {
+  "node-awslambda": "javascript-awslambda",
+  "node-azurefunctions": "javascript-azurefunctions",
+  "node-cloudflare-pages": "javascript-cloudflare-pages",
+  "node-cloudflare-workers": "javascript-cloudflare-workers",
+  "node-connect": "javascript-connect",
+  "node-express": "javascript-express",
+  "node-fastify": "javascript-fastify",
+  "node-gcpfunctions": "javascript-gcpfunctions",
+  "node-hapi": "javascript-hapi",
+  "node-koa": "javascript-koa",
+  "node-nestjs": "javascript-nestjs",
+  "node-serverlesscloud": "javascript-serverlesscloud",
+}
+
 function normalizePlatform(platform: string): string {
   // sentry uses format python-django, but docs uses python.django
   // this function normalizes that
-  return platform.replace(".", "-");
+  const dashedPlatform =  platform.replace(".", "-");
+
+  return NODE_TO_JS_MAP[dashedPlatform as keyof typeof NODE_TO_JS_MAP] ?? dashedPlatform
 }
 
 function getIcon(platform: string): Platform {

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -254,7 +254,8 @@ function normalizePlatform(platform: string): string {
   // this function normalizes that
   const dashedPlatform =  platform.replace(".", "-");
 
-  return NODE_TO_JS_MAP[dashedPlatform as keyof typeof NODE_TO_JS_MAP] ?? dashedPlatform
+  // Allow `node` as an alias for `javascript` to ensure backwards compatibility
+  return dashedPlatform.replace(/^node-/, 'javascript-')
 }
 
 function getIcon(platform: string): Platform {


### PR DESCRIPTION
This change will break the const platforms for users, but it’s likely only used in the [Sentry icon stories](https://github.com/getsentry/sentry/blob/2291c92013238b33e4bf2f82a26518b3586655e3/static/app/icons/icons.stories.tsx#L3). I considered adding `@deprecation` warning types, but since [Object.keys()](https://github.com/getsentry/platformicons/blob/412d8ca3b3513b98722ed48f05730bef8d7e1b5b/src/index.tsx#L5) removes the types, it didn’t seem effective.

Other than that, users using the component `<PlatformIcons />` passing a platform with a 'node-' prefix will be unaffected


contributes to 

- https://github.com/getsentry/sentry/issues/83988