### PR TITLE
feat: add nitro framework icon

### DIFF
--- a/src/icons.generated.ts
+++ b/src/icons.generated.ts
@@ -144,6 +144,7 @@ import nextjs from '../svg/nextjs.svg';
 import nintendo from '../svg/nintendo.svg';
 import nintendo_switch from '../svg/nintendo-switch.svg';
 import nintendo_switch_2 from '../svg/nintendo-switch-2.svg';
+import nitro from '../svg/nitro.svg';
 import nodejs from '../svg/nodejs.svg';
 import nuxt from '../svg/nuxt.svg';
 import nvidia from '../svg/nvidia.svg';
@@ -366,6 +367,7 @@ import nextjs_lg from '../svg_80x80/nextjs.svg';
 import nintendo_lg from '../svg_80x80/nintendo.svg';
 import nintendo_switch_lg from '../svg_80x80/nintendo-switch.svg';
 import nintendo_switch_2_lg from '../svg_80x80/nintendo-switch-2.svg';
+import nitro_lg from '../svg_80x80/nitro.svg';
 import nodejs_lg from '../svg_80x80/nodejs.svg';
 import nuxt_lg from '../svg_80x80/nuxt.svg';
 import nvidia_lg from '../svg_80x80/nvidia.svg';
@@ -589,6 +591,7 @@ export const icons: Record<string, string> = {
   "nintendo": nintendo,
   "nintendo-switch": nintendo_switch,
   "nintendo-switch-2": nintendo_switch_2,
+  "nitro": nitro,
   "nodejs": nodejs,
   "nuxt": nuxt,
   "nvidia": nvidia,
@@ -813,6 +816,7 @@ export const iconsLg: Record<string, string> = {
   "nintendo": nintendo_lg,
   "nintendo-switch": nintendo_switch_lg,
   "nintendo-switch-2": nintendo_switch_2_lg,
+  "nitro": nitro_lg,
   "nodejs": nodejs_lg,
   "nuxt": nuxt_lg,
   "nvidia": nvidia_lg,

--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -119,6 +119,7 @@ export const PLATFORM_TO_ICON = {
   "javascript-million": "million",
   "javascript-nestjs": "nestjs",
   "javascript-nextjs": "nextjs",
+  "javascript-nitro": "nitro",
   "javascript-node": "nodejs",
   "javascript-nuxt": "nuxt",
   "javascript-opennext": "opennext",

--- a/svg/nitro.svg
+++ b/svg/nitro.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+  <rect width="100%" height="100%" fill="#fff"/>
+  <g transform="translate(2 2) scale(0.4)">
+    <g clip-path="url(#nitro_clip)">
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M35.2166 7.02016C28.0478 -1.38317 15.4241 -2.38397 7.02077 4.78481C-1.38256 11.9536 -2.38336 24.5773 4.78542 32.9806C11.9542 41.3839 24.5779 42.3847 32.9812 35.216C41.3846 28.0472 42.3854 15.4235 35.2166 7.02016ZM25.2525 17.5175C26.0233 17.5175 26.5155 18.3527 26.1287 19.0194L26.0175 19.2111L18.4696 31.6294C18.3293 31.8602 18.0788 32.001 17.8088 32.001H17.0883C16.5946 32.001 16.2336 31.5349 16.3573 31.0569L18.4054 23.1384C18.5691 22.5053 18.0912 21.888 17.4373 21.888H14.2914C13.6375 21.888 13.1596 21.2708 13.3232 20.6377L16.4137 8.68289C16.5261 8.28056 16.8904 7.99734 17.3081 8.00208C17.3587 8.00266 17.4046 8.0035 17.4427 8.0047L20.6109 8.00465C21.217 8.00436 21.684 8.53896 21.6023 9.13949L21.5828 9.28246L20.3746 16.349C20.2702 16.9598 20.7406 17.5175 21.3603 17.5175H25.2525Z" fill="url(#nitro_grad)"/>
+    </g>
+  </g>
+  <defs>
+    <radialGradient id="nitro_grad" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(4 20) scale(39 397.71)">
+      <stop stop-color="#31B2F3"/>
+      <stop offset="0.473958" stop-color="#F27CEC"/>
+      <stop offset="1" stop-color="#FD6641"/>
+    </radialGradient>
+    <clipPath id="nitro_clip">
+      <rect width="40" height="40" fill="#fff"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/svg_80x80/nitro.svg
+++ b/svg_80x80/nitro.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" fill="none">
+  <rect width="100%" height="100%" fill="#fff"/>
+  <g transform="translate(8 8) scale(1.6)">
+    <g clip-path="url(#nitro_clip)">
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M35.2166 7.02016C28.0478 -1.38317 15.4241 -2.38397 7.02077 4.78481C-1.38256 11.9536 -2.38336 24.5773 4.78542 32.9806C11.9542 41.3839 24.5779 42.3847 32.9812 35.216C41.3846 28.0472 42.3854 15.4235 35.2166 7.02016ZM25.2525 17.5175C26.0233 17.5175 26.5155 18.3527 26.1287 19.0194L26.0175 19.2111L18.4696 31.6294C18.3293 31.8602 18.0788 32.001 17.8088 32.001H17.0883C16.5946 32.001 16.2336 31.5349 16.3573 31.0569L18.4054 23.1384C18.5691 22.5053 18.0912 21.888 17.4373 21.888H14.2914C13.6375 21.888 13.1596 21.2708 13.3232 20.6377L16.4137 8.68289C16.5261 8.28056 16.8904 7.99734 17.3081 8.00208C17.3587 8.00266 17.4046 8.0035 17.4427 8.0047L20.6109 8.00465C21.217 8.00436 21.684 8.53896 21.6023 9.13949L21.5828 9.28246L20.3746 16.349C20.2702 16.9598 20.7406 17.5175 21.3603 17.5175H25.2525Z" fill="url(#nitro_grad)"/>
+    </g>
+  </g>
+  <defs>
+    <radialGradient id="nitro_grad" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(4 20) scale(39 397.71)">
+      <stop stop-color="#31B2F3"/>
+      <stop offset="0.473958" stop-color="#F27CEC"/>
+      <stop offset="1" stop-color="#FD6641"/>
+    </radialGradient>
+    <clipPath id="nitro_clip">
+      <rect width="40" height="40" fill="#fff"/>
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
Adds the Nitro framework icon (sourced from https://nitro.build/icon.svg) as `javascript-nitro`

I made sure to wrap the original 40×40 gradient circle logo in `translate + scale` so it sits with ~10% padding inside both the 20×20 and 80×80 viewBoxes, to match similar existing icons. I also added a white background rect so the evenodd "N" cutout stays readable on dark UIs.

