### PR TITLE
feat: add google platform alias

### DIFF
--- a/src/platformIcon.tsx
+++ b/src/platformIcon.tsx
@@ -72,6 +72,7 @@ export const PLATFORM_TO_ICON = {
   "go-martini": "martini",
   "go-negroni": "go",
   godot: "godot",
+  google: "google",
   grok: "grok",
   groq: "groq",
   huggingface: "huggingface",


### PR DESCRIPTION
The `svg/google.svg` and `svg_80x80/google.svg` files have shipped since 2020 but no entry in `PLATFORM_TO_ICON` exposes them. As a result, `<PlatformIcon platform="google" />` returns the default icon instead of the Google "G".

Adding the one-line alias so callers can render the existing asset.

### Why this matters

Sentry's `ContextIcon` is being migrated from the legacy `sentry-logos` set to platformicons. The legacy mapping had a dedicated Google logo for `device.brand: 'google'` (Pixel etc.); without this alias, the migration has to fall back to the Android icon, which is misleading — the icon represents the device brand, not the OS.

### Verification

- `svg/google.svg` and `svg_80x80/google.svg` exist on master.
- `icons.generated.ts` already imports both.
- `yarn generate` is a no-op after this change (the imports were already there).
- `yarn build` passes.